### PR TITLE
feat: add maintenance notice banner

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,8 @@ SUNDOG Light は、参加者のスマートフォン画面をイベント用ラ�
 - `NEXT_PUBLIC_GA_MEASUREMENT_ID` - 任意のGoogle Analytics ID。
 - `MAINTENANCE_MODE=true` - メンテナンスモードを有効化。
 - `MAINTENANCE_MESSAGE` - メンテナンス画面/API向けの任意メッセージ。
+- `MAINTENANCE_NOTICE_MODE=true` - メンテナンス予告バーを有効化。
+- `MAINTENANCE_NOTICE_MESSAGE` - メンテナンス予告バー向けの任意メッセージ。
 
 ## 実装ガイド
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,28 @@ MAINTENANCE_MESSAGE="サービス更新作業のため、一時的に停止し�
 2. 必要な更新作業を実施する。
 3. 動作確認後、`MAINTENANCE_MODE=false` または未設定にして再デプロイする。
 
+## Maintenance Notice Mode
+
+メンテナンス予定を事前告知したい場合は、環境変数でメンテナンス予告を有効にします。
+
+```bash
+MAINTENANCE_NOTICE_MODE=true
+```
+
+必要に応じて表示文言も変更できます。
+
+```bash
+MAINTENANCE_NOTICE_MESSAGE="6/30 22:00-23:00 にメンテナンスを予定しています。"
+```
+
+メンテナンス予告中の挙動:
+
+- `/` のランディングページは通常どおり表示し、告知バーは表示しません。
+- `/login`, `/event/*` のホスト向け画面に告知バーを表示します。
+- `/client/*` の参加者ライト画面には表示しません。
+- APIは通常どおり動作します。
+- `MAINTENANCE_MODE=true` の実メンテナンス中は、メンテナンスモードを優先し、予告バーは表示しません。
+
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.

--- a/src/app/(host)/layout.tsx
+++ b/src/app/(host)/layout.tsx
@@ -1,4 +1,5 @@
 import { auth, signOut } from "@/auth";
+import MaintenanceNoticeBanner from "@/features/core/components/MaintenanceNoticeBanner";
 import SundogLightHeader from "@/features/core/components/SundogLightHeader";
 import React from "react";
 import { Toaster } from "react-hot-toast";
@@ -25,6 +26,7 @@ export default async function RootLayout({
                     }}
                 />
             </header>
+            <MaintenanceNoticeBanner maxWidthClassName="max-w-lg" />
             <main className={`w-full flex-grow max-w-lg`}>{children}</main>
             <Toaster position="top-center" />
         </div>

--- a/src/features/core/components/MaintenanceNoticeBanner.tsx
+++ b/src/features/core/components/MaintenanceNoticeBanner.tsx
@@ -1,0 +1,33 @@
+import {
+    getMaintenanceNoticeMessage,
+    isMaintenanceNoticeVisible,
+} from "@/lib/maintenance";
+
+export default function MaintenanceNoticeBanner({
+    maxWidthClassName = "max-w-5xl",
+}: {
+    maxWidthClassName?: string;
+}) {
+    if (!isMaintenanceNoticeVisible()) {
+        return null;
+    }
+
+    const message = getMaintenanceNoticeMessage();
+
+    return (
+        <aside
+            className="mb-6 w-full bg-sky-200 text-black"
+            role="status"
+            aria-live="polite"
+        >
+            <div
+                className={`mx-auto flex w-full ${maxWidthClassName} flex-col gap-1 px-4 py-3 text-center sm:flex-row sm:items-center sm:justify-center sm:gap-3`}
+            >
+                <span className="text-xs font-bold">メンテナンス予定</span>
+                <span className="text-sm leading-6 text-gray-700">
+                    {message}
+                </span>
+            </div>
+        </aside>
+    );
+}

--- a/src/lib/maintenance.ts
+++ b/src/lib/maintenance.ts
@@ -8,9 +8,26 @@ export function isMaintenanceModeEnabled(): boolean {
     );
 }
 
+export function isMaintenanceNoticeEnabled(): boolean {
+    return TRUE_VALUES.has(
+        (process.env.MAINTENANCE_NOTICE_MODE ?? "").trim().toLowerCase()
+    );
+}
+
+export function isMaintenanceNoticeVisible(): boolean {
+    return isMaintenanceNoticeEnabled() && !isMaintenanceModeEnabled();
+}
+
 export function getMaintenanceMessage(): string {
     return (
         process.env.MAINTENANCE_MESSAGE ??
         "サービス更新作業のため、一時的に停止しています。完了までしばらくお待ちください。"
+    );
+}
+
+export function getMaintenanceNoticeMessage(): string {
+    return (
+        process.env.MAINTENANCE_NOTICE_MESSAGE ??
+        "近日中にメンテナンスを予定しています。作業中はログイン後の操作と参加者画面への接続を一時停止します。"
     );
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a visible maintenance notice banner that can appear across the app.
  * Introduced a separate notice mode with its own message, distinct from full maintenance mode.

* **Documentation**
  * Updated setup docs to explain the new notice-related settings and how notice mode behaves compared with regular maintenance mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->