### PR TITLE
fix: connect color socket directly to API

### DIFF
--- a/next.config.test.ts
+++ b/next.config.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+    createBackendRewrites,
     createLegacyRedirects,
     resolveBackendBaseUrl,
 } from "./next.config";
@@ -26,6 +27,28 @@ describe("resolveBackendBaseUrl", () => {
                 NODE_ENV: "production",
             })
         ).toBe("https://api.example.com");
+    });
+});
+
+describe("createBackendRewrites", () => {
+    it("proxies WebSocket requests only when using the local backend", () => {
+        expect(
+            createBackendRewrites({ NODE_ENV: "development" })
+        ).toContainEqual({
+            source: "/ws/:path*",
+            destination: "http://localhost:8080/ws/:path*",
+        });
+
+        expect(
+            createBackendRewrites({
+                NEXT_PUBLIC_API_BASE_URL: "https://api.example.com",
+                NODE_ENV: "production",
+            })
+        ).not.toContainEqual(
+            expect.objectContaining({
+                source: expect.stringMatching(/^\/ws/),
+            })
+        );
     });
 });
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -69,16 +69,8 @@ const nextConfig: NextConfig = {
                 destination: `${backendBaseUrl}/login/google`,
             },
             {
-                source: "/ws",
-                destination: `${backendBaseUrl}/ws`,
-            },
-            {
                 source: "/api/:path*",
                 destination: `${backendBaseUrl}/api/:path*`,
-            },
-            {
-                source: "/ws/:path*",
-                destination: `${backendBaseUrl}/ws/:path*`,
             },
         ];
     },

--- a/next.config.ts
+++ b/next.config.ts
@@ -33,6 +33,40 @@ export function resolveBackendBaseUrl(
     return LOCAL_BACKEND_BASE_URL;
 }
 
+export function createBackendRewrites(
+    environment: BackendEnvironment = {
+        NEXT_PUBLIC_API_BASE_URL: process.env.NEXT_PUBLIC_API_BASE_URL,
+        NODE_ENV: process.env.NODE_ENV,
+    }
+) {
+    const backendBaseUrl = resolveBackendBaseUrl(environment);
+    const rewrites = [
+        {
+            source: "/login/google",
+            destination: `${backendBaseUrl}/login/google`,
+        },
+        {
+            source: "/api/:path*",
+            destination: `${backendBaseUrl}/api/:path*`,
+        },
+    ];
+
+    if (!environment.NEXT_PUBLIC_API_BASE_URL?.trim()) {
+        rewrites.push(
+            {
+                source: "/ws",
+                destination: `${backendBaseUrl}/ws`,
+            },
+            {
+                source: "/ws/:path*",
+                destination: `${backendBaseUrl}/ws/:path*`,
+            }
+        );
+    }
+
+    return rewrites;
+}
+
 export function createLegacyRedirects(
     canonicalOrigin: string,
     legacyHosts: string[]
@@ -61,18 +95,7 @@ const nextConfig: NextConfig = {
         return createLegacyRedirects(canonicalOrigin, resolveLegacyHosts());
     },
     async rewrites() {
-        const backendBaseUrl = resolveBackendBaseUrl();
-
-        return [
-            {
-                source: "/login/google",
-                destination: `${backendBaseUrl}/login/google`,
-            },
-            {
-                source: "/api/:path*",
-                destination: `${backendBaseUrl}/api/:path*`,
-            },
-        ];
+        return createBackendRewrites();
     },
 };
 

--- a/src/features/event/lib/color-websocket.test.ts
+++ b/src/features/event/lib/color-websocket.test.ts
@@ -1,4 +1,11 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+    afterEach,
+    beforeEach,
+    describe,
+    expect,
+    it,
+    vi,
+} from "vitest";
 import { connectColorSocket } from "./color-websocket";
 
 type ConnectSuccess = (frame: string) => void;
@@ -11,6 +18,7 @@ describe("connectColorSocket", () => {
     let messageCallback: MessageCallback | null;
     let rawSocketClose: ReturnType<typeof vi.fn>;
     let unsubscribe: ReturnType<typeof vi.fn>;
+    let socketUrl: string | null;
     let client: {
         connected: boolean;
         debug: (message: string) => void;
@@ -26,6 +34,7 @@ describe("connectColorSocket", () => {
         messageCallback = null;
         rawSocketClose = vi.fn();
         unsubscribe = vi.fn();
+        socketUrl = null;
 
         client = {
             connected: false,
@@ -56,7 +65,7 @@ describe("connectColorSocket", () => {
             close = rawSocketClose;
 
             constructor(url: string) {
-                void url;
+                socketUrl = url;
             }
         }
 
@@ -64,6 +73,10 @@ describe("connectColorSocket", () => {
         window.Stomp = {
             over: () => client,
         };
+    });
+
+    afterEach(() => {
+        vi.unstubAllEnvs();
     });
 
     it("closes a connecting transport and ignores its late error", () => {
@@ -169,5 +182,31 @@ describe("connectColorSocket", () => {
                 color: null,
             })
         );
+    });
+
+    it("connects directly to the configured API WebSocket endpoint", () => {
+        vi.stubEnv("NEXT_PUBLIC_API_BASE_URL", "https://api.example.com/");
+
+        connectColorSocket({
+            eventId: "event-id",
+            onConnected: vi.fn(),
+            onColorChanged: vi.fn(),
+            onError: vi.fn(),
+        });
+
+        expect(socketUrl).toBe("https://api.example.com/ws");
+    });
+
+    it("uses the local backend when the API base URL is not configured", () => {
+        vi.stubEnv("NEXT_PUBLIC_API_BASE_URL", "");
+
+        connectColorSocket({
+            eventId: "event-id",
+            onConnected: vi.fn(),
+            onColorChanged: vi.fn(),
+            onError: vi.fn(),
+        });
+
+        expect(socketUrl).toBe("http://localhost:8080/ws");
     });
 });

--- a/src/features/event/lib/color-websocket.test.ts
+++ b/src/features/event/lib/color-websocket.test.ts
@@ -197,7 +197,7 @@ describe("connectColorSocket", () => {
         expect(socketUrl).toBe("https://api.example.com/ws");
     });
 
-    it("uses the local backend when the API base URL is not configured", () => {
+    it("uses the same-origin proxy when the API base URL is not configured", () => {
         vi.stubEnv("NEXT_PUBLIC_API_BASE_URL", "");
 
         connectColorSocket({
@@ -207,6 +207,6 @@ describe("connectColorSocket", () => {
             onError: vi.fn(),
         });
 
-        expect(socketUrl).toBe("http://localhost:8080/ws");
+        expect(socketUrl).toBe("/ws");
     });
 });

--- a/src/features/event/lib/color-websocket.ts
+++ b/src/features/event/lib/color-websocket.ts
@@ -85,6 +85,17 @@ function getSocketLibraries() {
     };
 }
 
+function resolveColorSocketUrl() {
+    const configuredBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL?.trim();
+
+    if (!configuredBaseUrl) {
+        // ローカル開発用
+        return "http://localhost:8080/ws";
+    }
+
+    return `${configuredBaseUrl.replace(/\/$/, "")}/ws`;
+}
+
 export function connectColorSocket({
     eventId,
     onConnected,
@@ -92,7 +103,7 @@ export function connectColorSocket({
     onError,
 }: ConnectColorSocketOptions): ColorSocketConnection {
     const { SockJS, Stomp } = getSocketLibraries();
-    const socket = new SockJS("/ws");
+    const socket = new SockJS(resolveColorSocketUrl());
     const client = Stomp.over(socket);
     let subscription: StompSubscription | null = null;
     let isDisposed = false;

--- a/src/features/event/lib/color-websocket.ts
+++ b/src/features/event/lib/color-websocket.ts
@@ -89,8 +89,7 @@ function resolveColorSocketUrl() {
     const configuredBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL?.trim();
 
     if (!configuredBaseUrl) {
-        // ローカル開発用
-        return "http://localhost:8080/ws";
+        return "/ws";
     }
 
     return `${configuredBaseUrl.replace(/\/$/, "")}/ws`;


### PR DESCRIPTION
## Summary

- connect the color socket directly to the configured API origin
- remove the unused WebSocket rewrites from the Next.js configuration
- add regression coverage for configured and local-development socket URLs

## Why

The relative WebSocket route did not preserve the WebSocket transport end-to-end through the frontend hosting path. Using the configured API origin allows the client to establish the socket connection directly while retaining the local backend fallback for development.

## Impact

Host and participant color updates can use the WebSocket transport without relying on the frontend rewrite path. Existing REST API rewrites remain unchanged.

## Validation

- `mise exec -- pnpm test` (14 files, 72 tests)
- `mise exec -- pnpm lint` (0 errors; 4 existing image warnings)
- production `mise exec -- pnpm build`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved real-time event connections by using the configured API endpoint.
  * Added a reliable local-development fallback when no API endpoint is configured.
  * Updated API request routing to proxy through the backend service.
  * Removed obsolete websocket rewrite rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->